### PR TITLE
fixed require statement for node.js import

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Component
 ## Usage
 Require the library:
 
-	var web3 = require('web3');
+	var web3 = require('ethereum.js');
 
 Set a provider (QtSyncProvider, HttpSyncProvider)
 


### PR DESCRIPTION
In node.js, you have to require('ethereum.js'); the web3 module is not recognized.