### PR TITLE
Move browserify transforms to package.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,8 +47,6 @@ gulp.task('build', ['clean'], function () {
     return browserify(browserifyOptions)
         .require('./' + src + '.js', {expose: 'web3'})
         .add('./' + src + '.js')
-        .transform('envify', { NODE_ENV: 'build' })
-        .transform('unreachable-branch-transform')
         .bundle()
         .pipe(exorcist(path.join( DEST, dst + '.js.map')))
         .pipe(source(dst + '.js'))

--- a/package.json
+++ b/package.json
@@ -45,6 +45,19 @@
   "bugs": {
     "url": "https://github.com/ethereum/ethereum.js/issues"
   },
+  "browserify": {
+    "transform": [
+      [
+        "envify",
+        {
+          "NODE_ENV": "build"
+        }
+      ],
+      [
+        "unreachable-branch-transform"
+      ]
+    ]
+  },
   "keywords": [
     "ethereum",
     "javascript",


### PR DESCRIPTION
Browserify will automatically read the `package.json` and run the transforms. **This produces the exact same build** as specifying the transforms in the `gulpfile.js`. Additionally, now when someone tries to externally browserify `ethereum.js`, it will use the same transforms as when you use `gulp`. Yay! Consistency!

Fixes #86
Fixes #36