### PR TITLE
Browserify transforms must be in normal dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "bignumber.js": ">=2.0.0",
+    "envify": "^3.0.0",
+    "unreachable-branch-transform": "^0.1.0",
     "xmlhttprequest": "*"
   },
   "devDependencies": {
@@ -16,7 +18,6 @@
     "browserify": ">=6.0",
     "coveralls": "^2.11.2",
     "del": ">=0.1.1",
-    "envify": "^3.0.0",
     "exorcist": "^0.1.6",
     "gulp": ">=3.4.0",
     "gulp-jshint": ">=1.5.0",
@@ -27,7 +28,6 @@
     "jshint": ">=2.5.0",
     "mocha": ">=2.1.0",
     "mocha-lcov-reporter": "0.0.1",
-    "unreachable-branch-transform": "^0.1.0",
     "vinyl-source-stream": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Move `envify` and `unreachable-branch-transform` to normal dependencies for external browserify support.

This does not affect builds, but fixes external browserify support. Sorry for the trouble.