### PR TITLE
Renaming hash/stringXX to bytes

### DIFF
--- a/lib/solidity/abi.js
+++ b/lib/solidity/abi.js
@@ -57,7 +57,7 @@ var isArrayType = function (type) {
  */
 var dynamicTypeBytes = function (type, value) {
     // TODO: decide what to do with array of strings
-    if (isArrayType(type) || type === 'string')    // only string itself that is dynamic; stringX is static length.
+    if (isArrayType(type) || type === 'bytes')
         return f.formatInputInt(value.length);
     return "";
 };
@@ -98,7 +98,7 @@ var formatInput = function (inputs, params) {
             toAppendArrayContent += params[i].reduce(function (acc, curr) {
                 return acc + formatter(curr);
             }, "");
-        else if (inputs[i].type === 'string')
+        else if (inputs[i].type === 'bytes')
             toAppendArrayContent += formatter(params[i]);
         else
             toAppendConstant += formatter(params[i]);
@@ -117,7 +117,7 @@ var formatInput = function (inputs, params) {
  * @returns {Number} length of dynamic type, 0 or multiplication of ETH_PADDING (32)
  */
 var dynamicBytesLength = function (type) {
-    if (isArrayType(type) || type === 'string')   // only string itself that is dynamic; stringX is static length.
+    if (isArrayType(type) || type === 'bytes')
         return c.ETH_PADDING * 2;
     return 0;
 };
@@ -167,7 +167,7 @@ var formatOutput = function (outs, output) {
             }
             result.push(array);
         }
-        else if (types.prefixedType('string')(outs[i].type)) {
+        else if (types.prefixedType('bytes')(outs[i].type)) {
             dynamicPart = dynamicPart.slice(padding);
             result.push(formatter(output.slice(0, padding)));
             output = output.slice(padding);

--- a/lib/solidity/types.js
+++ b/lib/solidity/types.js
@@ -45,8 +45,7 @@ var inputTypes = function () {
     return [
         { type: prefixedType('uint'), format: f.formatInputInt },
         { type: prefixedType('int'), format: f.formatInputInt },
-        { type: prefixedType('hash'), format: f.formatInputInt },
-        { type: prefixedType('string'), format: f.formatInputString }, 
+        { type: prefixedType('bytes'), format: f.formatInputString }, 
         { type: prefixedType('real'), format: f.formatInputReal },
         { type: prefixedType('ureal'), format: f.formatInputReal },
         { type: namedType('address'), format: f.formatInputInt },
@@ -61,8 +60,7 @@ var outputTypes = function () {
     return [
         { type: prefixedType('uint'), format: f.formatOutputUInt },
         { type: prefixedType('int'), format: f.formatOutputInt },
-        { type: prefixedType('hash'), format: f.formatOutputHash },
-        { type: prefixedType('string'), format: f.formatOutputString },
+        { type: prefixedType('bytes'), format: f.formatOutputString },
         { type: prefixedType('real'), format: f.formatOutputReal },
         { type: prefixedType('ureal'), format: f.formatOutputUReal },
         { type: namedType('address'), format: f.formatOutputAddress },

--- a/test/abi.inputParser.js
+++ b/test/abi.inputParser.js
@@ -227,56 +227,6 @@ describe('abi', function() {
 
         });
 
-        it('should parse input hash', function() {
-
-            // given
-            var d = clone(description);
-
-            d[0].inputs = [
-                { type: "hash" }
-            ];
-
-            // when
-            var parser = abi.inputParser(d);
-
-            // then
-            assert.equal(parser.test("0x407d73d8a49eeb85d32cf465507dd71d507100c1"), "000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1");
-
-        });
-
-        it('should parse input hash256', function() {
-
-            // given
-            var d = clone(description);
-
-            d[0].inputs = [
-                { type: "hash256" }
-            ];
-
-            // when
-            var parser = abi.inputParser(d);
-
-            // then
-            assert.equal(parser.test("0x407d73d8a49eeb85d32cf465507dd71d507100c1"), "000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1");
-
-        });
-
-
-        it('should parse input hash160', function() {
-            // given
-            var d = clone(description);
-
-            d[0].inputs = [
-                { type: "hash160" }
-            ];
-
-            // when
-            var parser = abi.inputParser(d);
-
-            // then
-            assert.equal(parser.test("0x407d73d8a49eeb85d32cf465507dd71d507100c1"), "000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1");
-        });
-
         it('should parse input address', function () {
 
             // given
@@ -294,13 +244,13 @@ describe('abi', function() {
 
         });
 
-        it('should parse input string', function () {
+        it('should parse input fixed bytes type', function () {
 
             // given
             var d = clone(description);
 
             d[0].inputs = [
-                { type: "string" }
+                { type: "bytes32" }
             ];
 
             // when
@@ -318,14 +268,14 @@ describe('abi', function() {
                 );
         });
 
-        it('should parse input int followed by a string', function () {
+        it('should parse input int followed by a fixed bytes type', function () {
 
             // given
             var d = clone(description);
 
             d[0].inputs = [
                 { type: "int" },
-                { type: "string" }
+                { type: "bytes32" }
             ];
 
             // when
@@ -340,13 +290,13 @@ describe('abi', function() {
                 );
         });
 
-        it('should parse input string followed by an int', function () {
+        it('should parse input fixed bytes type followed by an int', function () {
 
             // given
             var d = clone(description);
 
             d[0].inputs = [
-                { type: "string" },
+                { type: "bytes32" },
                 { type: "int" }
             ];
 
@@ -391,8 +341,8 @@ describe('abi', function() {
             },{
                 name: "test2",
                 type: "function",
-                inputs: [{ type: "string" }],
-                outputs: [{ type: "string" }]
+                inputs: [{ type: "bytes32" }],
+                outputs: [{ type: "bytes32" }]
             }];
 
             // when

--- a/test/abi.inputParser.js
+++ b/test/abi.inputParser.js
@@ -250,7 +250,7 @@ describe('abi', function() {
             var d = clone(description);
 
             d[0].inputs = [
-                { type: "bytes32" }
+                { type: "bytes" }
             ];
 
             // when
@@ -275,7 +275,7 @@ describe('abi', function() {
 
             d[0].inputs = [
                 { type: "int" },
-                { type: "bytes32" }
+                { type: "bytes" }
             ];
 
             // when
@@ -296,7 +296,7 @@ describe('abi', function() {
             var d = clone(description);
 
             d[0].inputs = [
-                { type: "bytes32" },
+                { type: "bytes" },
                 { type: "int" }
             ];
 
@@ -341,8 +341,8 @@ describe('abi', function() {
             },{
                 name: "test2",
                 type: "function",
-                inputs: [{ type: "bytes32" }],
-                outputs: [{ type: "bytes32" }]
+                inputs: [{ type: "bytes" }],
+                outputs: [{ type: "bytes" }]
             }];
 
             // when

--- a/test/abi.outputParser.js
+++ b/test/abi.outputParser.js
@@ -21,13 +21,13 @@ var description =  [{
 
 describe('abi', function() {
     describe('outputParser', function() {
-        it('should parse output string', function() {
+        it('should parse output fixed bytes type', function() {
 
             // given
             var d = clone(description);
 
             d[0].outputs = [
-                { type: "string" }
+                { type: "bytes32" }
             ];
 
             // when
@@ -181,64 +181,6 @@ describe('abi', function() {
             assert.equal(parser.test("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0")[0], -16);
         });
 
-        it('should parse output hash', function() {
-            
-            // given
-            var d = clone(description);
-
-            d[0].outputs = [
-                { type: 'hash' }
-            ];
-
-            // when
-            var parser = abi.outputParser(d);
-
-            // then
-            assert.equal(
-                parser.test("0x000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1")[0],
-                "0x000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1"
-                );
-        });
-        
-        it('should parse output hash256', function() {
-        
-            // given
-            var d = clone(description);
-
-            d[0].outputs = [
-                { type: 'hash256' }
-            ];
-
-            // when
-            var parser = abi.outputParser(d);
-
-            // then
-            assert.equal(
-                parser.test("0x000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1")[0],
-                "0x000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1"
-                );
-        });
-
-        it('should parse output hash160', function() {
-            
-            // given
-            var d = clone(description);
-
-            d[0].outputs = [
-                { type: 'hash160' }
-            ];
-
-            // when
-            var parser = abi.outputParser(d);
-
-            // then
-            assert.equal(
-                parser.test("0x000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1")[0],
-                "0x000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1"
-                );
-            // TODO shouldnt' the expected hash be shorter?
-        });
-
         it('should parse output address', function() {
             
             // given
@@ -317,14 +259,14 @@ describe('abi', function() {
         });
         
 
-        it('should parse multiple output strings', function() {
+        it('should parse multiple output fixed bytes type', function() {
 
             // given
             var d = clone(description);
 
             d[0].outputs = [
-                { type: "string" },
-                { type: "string" }
+                { type: "bytes32" },
+                { type: "bytes32" }
             ];
 
             // when
@@ -380,8 +322,8 @@ describe('abi', function() {
             },{
                 name: "test2",
                 type: "function",
-                inputs: [{ type: "string" }],
-                outputs: [{ type: "string" }]
+                inputs: [{ type: "bytes32" }],
+                outputs: [{ type: "bytes32" }]
             }];
 
             // when

--- a/test/abi.outputParser.js
+++ b/test/abi.outputParser.js
@@ -27,7 +27,7 @@ describe('abi', function() {
             var d = clone(description);
 
             d[0].outputs = [
-                { type: "bytes32" }
+                { type: "bytes" }
             ];
 
             // when
@@ -265,8 +265,8 @@ describe('abi', function() {
             var d = clone(description);
 
             d[0].outputs = [
-                { type: "bytes32" },
-                { type: "bytes32" }
+                { type: "bytes" },
+                { type: "bytes" }
             ];
 
             // when
@@ -322,8 +322,8 @@ describe('abi', function() {
             },{
                 name: "test2",
                 type: "function",
-                inputs: [{ type: "bytes32" }],
-                outputs: [{ type: "bytes32" }]
+                inputs: [{ type: "bytes" }],
+                outputs: [{ type: "bytes" }]
             }];
 
             // when


### PR DESCRIPTION
We have to rename the etherum.js types to conform with the changes in Solidity.

Is needed due to https://github.com/ethereum/cpp-ethereum/pull/1284

For now I only changed the tests.